### PR TITLE
Added talk descriptions and its styling.

### DIFF
--- a/docs/css/additional-styles.css
+++ b/docs/css/additional-styles.css
@@ -62,6 +62,27 @@
   list-style: inside;
 }
 
+.speakers-card-talk-title {
+  color: var(--dark-gray);
+  font-size: 1.5em;
+  margin-top: 0.5em;
+}
+
+.speakers-card-talk-subtitle {
+  font-weight: bold;
+  margin-top: 0.1em !important;
+  margin-bottom: 0.5em !important;
+  text-transform: uppercase;
+  color: var(--golden-yellow) !important;
+}
+
+.speakers-card-section-title {
+  color: var(--gopher-blue-dark);
+  margin-top: 1em;
+  margin-bottom: 0.1em;
+  font-weight: bold;
+}
+
 .divider.primary {
   background-color: var(--dark-gray);
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-us">
   <head>
-	<meta name="generator" content="Hugo 0.58.2" />
+	<meta name="generator" content="Hugo 0.58.3" />
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta http-equiv="x-ua-compatible" content="ie=edge">
@@ -232,6 +232,12 @@ if (!doNotTrack) {
           
         </h3>
         <h4 class="has-text-centered speakers-company">Google</h4>
+        <h4 class="has-text-centered speakers-card-talk-title" >10 years of Go</h4>
+        <h5 class="card-subtitle speakers-card-talk-subtitle has-text-centered">Talk</h5>
+        <h4 class="has-text-centered speakers-card-section-title">Description</h4>
+        <div class="speakers-bio has-text-justified">Simple. Reliable. Efficient. These words defined Go on Nov 10 2009.  As we celebrate 10 yrs, we add one more: Sustainable. A reflection of Go: technological & industry advances during the last decade, while exploring what it means to be sustainable amidst constant change.</div>
+        
+        <h4 class="has-text-centered speakers-card-section-title">About Carmen Andoh</h4>
         <div class="speakers-bio has-text-justified">Carmen is the Open Source Strategy Lead for Go at Google. She was previously Build Infrastructure Engineer at Travis CI Operations at Enquos.</div>
       </li>
       
@@ -248,6 +254,12 @@ if (!doNotTrack) {
           
         </h3>
         <h4 class="has-text-centered speakers-company">PaperCut</h4>
+        <h4 class="has-text-centered speakers-card-talk-title" >PDF Full Text Search in Pure Go. Why and How I Wrote it.</h4>
+        <h5 class="card-subtitle speakers-card-talk-subtitle has-text-centered">Talk</h5>
+        <h4 class="has-text-centered speakers-card-section-title">Description</h4>
+        <div class="speakers-bio has-text-justified"><p>Many modern software product developers work close to the top of a powerful open source software stack and focus on their customer problems.</p> <p>This talk is about how I worked further down the Go software stack to write a PDF Full Text Search library and solve customer problems in unexpected ways.</p>.</div>
+        
+        <h4 class="has-text-centered speakers-card-section-title">About Peter Williams</h4>
         <div class="speakers-bio has-text-justified"><p><a href="https://www.linkedin.com/in/peterwilliams97/">Peter Williams</a> is the lead developer of enabling technologies at <a href="https://www.papercut.com/">PaperCut</a>. He develops libraries and features for PaperCut´s products.</p> <p>Peter has been developing in Go for the last few years. Some of the features and components he has recently written in Go for PaperCut are</p> <ul> <li>A printing back-end for Google Cloud Print.</li> <li>A printing back-end and IPP stack for PaperCut Mobility.</li> <li>PDF grayscale conversion.</li> <li>PDF watermarking.</li> </ul></div>
       </li>
       
@@ -264,6 +276,12 @@ if (!doNotTrack) {
           
         </h3>
         <h4 class="has-text-centered speakers-company">Australian Broadcasting Corporation</h4>
+        <h4 class="has-text-centered speakers-card-talk-title" >Game of Clicks: Reinforcement Learning for News Recommendation</h4>
+        <h5 class="card-subtitle speakers-card-talk-subtitle has-text-centered">Talk</h5>
+        <h4 class="has-text-centered speakers-card-section-title">Description</h4>
+        <div class="speakers-bio has-text-justified"> <p>Recommendation systems suck. I buy one vacuum cleaner and all of a sudden I&#39;m a Hoover enthusiast. Enjoyed a nice video about politics? YouTube is unusable now.</p> <p>This talk covers a new way to build these systems using Deep Reinforcement Learning to improve the quality &amp; diversity of recommendations.</p></div>
+        
+        <h4 class="has-text-centered speakers-card-section-title">About Gareth Seneque</h4>
         <div class="speakers-bio has-text-justified">I am a Machine Learning Engineer at the ABC who is fascinated by ML, art, and the beguiling weirdness of human experience.
 Working at an organisation with a rich creative & cultural history (reflected in its data!) gives me the chance to experiment with a range of ML techniques on real-world 'big data'. Specifically, I am on the team that manages https://search.abc.net.au and our recommendation platform.
 I have also co-authored the recently-released 'Hands-on Deep Learning in Go', and presented at YOW! Data 2019 on the topic of 'Using Machine Learning to Automate Content Metadata'.</div>
@@ -284,6 +302,12 @@ I have also co-authored the recently-released 'Hands-on Deep Learning in Go', an
           
         </h3>
         <h4 class="has-text-centered speakers-company">Kablamo</h4>
+        <h4 class="has-text-centered speakers-card-talk-title" >Sloc Cloc and Code - Can a crusty Go program outperform a well written Rust Project?</h4>
+        <h5 class="card-subtitle speakers-card-talk-subtitle has-text-centered">Talk</h5>
+        <h4 class="has-text-centered speakers-card-section-title">Description</h4>
+        <div class="speakers-bio has-text-justified"><p>Sloc cloc and code. How a death march project lead to learning Go, the creation of a source lines of code counter which is faster and more accurate then the Rust/ATS/C equivalents, while learning about some really bizarre performance characteristics.</p></div>
+        
+        <h4 class="has-text-centered speakers-card-section-title">About Ben Boyter</h4>
         <div class="speakers-bio has-text-justified">A technical lead for Kablamo but at heart a codemonkey. I write about various topics on my blog https://boyter.org/ which occasionally makes the front of the orange site, as well as run searchcode.com as a side gig for fun. I like writing code, walks on beach and getting caught in the rain. I hate eating raw tomato unless you prepare it somehow, and slices on a hamburger does not count as preparation.</div>
       </li>
       
@@ -300,6 +324,12 @@ I have also co-authored the recently-released 'Hands-on Deep Learning in Go', an
           
         </h3>
         <h4 class="has-text-centered speakers-company">Kablamo</h4>
+        <h4 class="has-text-centered speakers-card-talk-title" >Getting Started with Deep Learning in Go</h4>
+        <h5 class="card-subtitle speakers-card-talk-subtitle has-text-centered">Talk</h5>
+        <h4 class="has-text-centered speakers-card-section-title">Description</h4>
+        <div class="speakers-bio has-text-justified"><p>Have you ever wanted to dabble in Deep Learning? Here&#39;s your chance to get started doing it in Go. We&#39;ll take you through a quick example of a new model - and then how to continue your learning process through more commonly found Tensorflow projects lying around the Internet.</p></div>
+        
+        <h4 class="has-text-centered speakers-card-section-title">About Darrell Chua</h4>
         <div class="speakers-bio has-text-justified">Darrell is a Senior Data Scientist with more than 10 years of experience. He has been programming in Go for a few years and has been working on Deep Learning models for longer. He has developed models of varying complexity; from building credit scorecards with logistic regression to building image classification models for trading cards.</div>
       </li>
       
@@ -318,6 +348,12 @@ I have also co-authored the recently-released 'Hands-on Deep Learning in Go', an
           
         </h3>
         <h4 class="has-text-centered speakers-company">GoJek</h4>
+        <h4 class="has-text-centered speakers-card-talk-title" >Go Gamble on Unicorn</h4>
+        <h5 class="card-subtitle speakers-card-talk-subtitle has-text-centered">Talk</h5>
+        <h4 class="has-text-centered speakers-card-section-title">Description</h4>
+        <div class="speakers-bio has-text-justified"><p>We will be going through the journey of scaling a company to unicorn, I am going to talk about how GoLang helped us scale 6000x over 36 months and 18+ product lines,  where we failed and excelled with GoLang. Welcome to our journey and learnings of building software, teams and products</p></div>
+        
+        <h4 class="has-text-centered speakers-card-section-title">About Ajey Gore</h4>
         <div class="speakers-bio has-text-justified">Ajey Gore is group CTO at GO-JEK primarily focussing on Payments and organisation wide technology and team strategies. He helps the group deliver a transport, logistics, lifestyle and payments platform of 20 products. Ajey has 18 years of experience building core technology strategy across diverse domains. His interests include machine learning, computer networks and distributed architecture system.
 Ajey founded CodeIgnition, a boutique DevOps consultancy. CodeIgnition was later acquired by GO-JEK. He served as ThoughtWorks's Head of Technology, a noted international technology consulting firm, following which he joined Hoppr as Chief Technology Officer, a Bharati SoftBank funded started, later acquired by Hike Messenger in India.
 An active influencer in the technology community, He is a trustee of the Emerging Technology Trust, a-not-for-profit organization.  Ajey organizes technology conferences, including RubyConf, GopherCon, and devopsdays  In India for last 8 years, through his not-for-profit organization. </div>
@@ -338,6 +374,12 @@ An active influencer in the technology community, He is a trustee of the Emergin
           
         </h3>
         <h4 class="has-text-centered speakers-company">Vend</h4>
+        <h4 class="has-text-centered speakers-card-talk-title" >Designing Go services for Continuous Deployment</h4>
+        <h5 class="card-subtitle speakers-card-talk-subtitle has-text-centered">Talk</h5>
+        <h4 class="has-text-centered speakers-card-section-title">Description</h4>
+        <div class="speakers-bio has-text-justified"><p>Continuous Delivery can drive the design of your code for Great Good. I&#39;ll share some of the tricks and strategies I&#39;ve used to deploy Go services safely, smoothly, and without ceremony. I&#39;ll cover integration testing, db migrations, zero-downtime deploys, feature flags, and some useful go tooling.</p></div>
+        
+        <h4 class="has-text-centered speakers-card-section-title">About Am Laher</h4>
         <div class="speakers-bio has-text-justified"><p>I&#39;ve been an avid Gopher since 2012 - roughly as long as I&#39;ve been living in New Zealand. I discovered such an immediate productivity boost, that I haven&#39;t looked back from Go, or NZ, since. I helped start the Go Auckland meetup group in 2013, and I&#39;ve hosted and spoken at many meetups since then.</p> <p>About four years ago, a wise man persuaded me that &quot;setting up a new stack is the right time to begin CD&quot;. I claimed I was too busy getting product and platform to market, but he won me over: &quot;it&#39;s much harder to add CD later&quot;. I went with it, and I was so chuffed with the results that I&#39;ve been championing CD-related approaches ever since.</p></div>
       </li>
       
@@ -354,6 +396,12 @@ An active influencer in the technology community, He is a trustee of the Emergin
           
         </h3>
         <h4 class="has-text-centered speakers-company">Atlassian</h4>
+        <h4 class="has-text-centered speakers-card-talk-title" >Eliminate the guess work: Profiling a go service in production</h4>
+        <h5 class="card-subtitle speakers-card-talk-subtitle has-text-centered">Talk</h5>
+        <h4 class="has-text-centered speakers-card-section-title">Description</h4>
+        <div class="speakers-bio has-text-justified"><p>This talk is about how to start using go&#39;s profiling tools, instrument your code so that you can profile your services running in production and have less mystery in your life.</p> <p>Viewers will learn how to use trace and pprof tools, and guidance on doing it in production for their own services.</p></div>
+        
+        <h4 class="has-text-centered speakers-card-section-title">About Alexander Else</h4>
         <div class="speakers-bio has-text-justified"><p>Alexander is an infrastructure software engineer, currently working at Atlassian on the Observability team. I like to build distributed systems. Sometimes things catch on fire and need putting out. When I&#39;m not doing those things I enjoy working on electronics projects, making music and spending time with my family.</p></div>
       </li>
       
@@ -372,6 +420,12 @@ An active influencer in the technology community, He is a trustee of the Emergin
           
         </h3>
         <h4 class="has-text-centered speakers-company">GreenSync</h4>
+        <h4 class="has-text-centered speakers-card-talk-title" >Pragmatic Concurrency</h4>
+        <h5 class="card-subtitle speakers-card-talk-subtitle has-text-centered">Talk</h5>
+        <h4 class="has-text-centered speakers-card-section-title">Description</h4>
+        <div class="speakers-bio has-text-justified"><p>Concurrency is one of Go&#39;s big selling points, but it&#39;s also something that trips up developers and  leads to projects stalling under the weight of complexity. I discuss my experience working on large concurrent systems, outline some common pitfalls, and share some opinions on best practices.</p></div>
+        
+        <h4 class="has-text-centered speakers-card-section-title">About Cera Davies</h4>
         <div class="speakers-bio has-text-justified"><p>I&#39;ve been coding Go since 2011. I&#39;m an infrastructure and platform engineer based in Melbourne, working in the energy sector on distributed &amp; renewable energy products. In my spare time I&#39;m into dancing, cycling, gabber, videogames &amp; politics. Mir veln zey iberlebn.</p></div>
       </li>
       
@@ -388,6 +442,12 @@ An active influencer in the technology community, He is a trustee of the Emergin
           
         </h3>
         <h4 class="has-text-centered speakers-company">ANZ Bank</h4>
+        <h4 class="has-text-centered speakers-card-talk-title" >Go for Decimals</h4>
+        <h5 class="card-subtitle speakers-card-talk-subtitle has-text-centered">Talk</h5>
+        <h4 class="has-text-centered speakers-card-section-title">Description</h4>
+        <div class="speakers-bio has-text-justified"><p>Relying on binary floating point can kill; they are inherently imprecise and can lead to technical complications later down the road. A decimal system would solve many of these complications. Go has been lacking a fast and efficient decimal data type, until now...</p></div>
+        
+        <h4 class="has-text-centered speakers-card-section-title">About Joshua Carpeggiani</h4>
         <div class="speakers-bio has-text-justified"><p>Josh is a software engineer at ANZ working on implementing an open source decimal datatype in Go as well as spreading the word about Go by co-organising a corporate Go training course. Outside of work, Josh likes to get lost by following the forgotten art of hitchhiking where he´s traveled to many places, and many are still to come.</p></div>
       </li>
       
@@ -406,6 +466,12 @@ An active influencer in the technology community, He is a trustee of the Emergin
           
         </h3>
         <h4 class="has-text-centered speakers-company">Atlassian</h4>
+        <h4 class="has-text-centered speakers-card-talk-title" >Migrate to a New Platform by Creating a Pipeline in Go</h4>
+        <h5 class="card-subtitle speakers-card-talk-subtitle has-text-centered">Talk</h5>
+        <h4 class="has-text-centered speakers-card-section-title">Description</h4>
+        <div class="speakers-bio has-text-justified"><p>This is the story of how Atlassian moved from a multi-million dollar contract with one vendor to another for their monitoring system. To help them migrate the thousands of engineers and microservices onto the new platform in just a few months, they built a new data pipeline using Go.</p></div>
+        
+        <h4 class="has-text-centered speakers-card-section-title">About Julia Wong</h4>
         <div class="speakers-bio has-text-justified"><p>Julia works as a developer in Atlassian´s Observability team. She loves learning about all things Go, especially the cute Gopher, and is passionate about teaching the younger generation how to code.</p></div>
       </li>
       

--- a/hugo/config.yaml
+++ b/hugo/config.yaml
@@ -200,8 +200,9 @@ params:
       keynote: true
       company: Google
       presentation:
-        title: ""
-        description: ""
+        title: "10 years of Go"
+        description: "Simple. Reliable. Efficient. These words defined Go on Nov 10 2009.  As we celebrate 10 yrs, we add one more: Sustainable. A reflection of Go: technological & industry advances during the last decade, while exploring what it means to be sustainable amidst constant change."
+        level: All levels
 
     - name: "Peter Williams"
       date: "31/10/2019"
@@ -226,6 +227,7 @@ recently written in Go for PaperCut are</p>
         title: "PDF Full Text Search in Pure Go. Why and How I Wrote it."
         description: '<p>Many modern software product developers work close to the top of a powerful open source software stack and focus on their customer problems.</p>
 <p>This talk is about how I worked further down the Go software stack to write a PDF Full Text Search library and solve customer problems in unexpected ways.</p>.'
+        level: All levels
 
     - name: "Gareth Seneque"
       date: "31/10/2019"
@@ -245,6 +247,7 @@ I have also co-authored the recently-released 'Hands-on Deep Learning in Go', an
         description: '
         <p>Recommendation systems suck. I buy one vacuum cleaner and all of a sudden I&#39;m a Hoover enthusiast. Enjoyed a nice video about politics? YouTube is unusable now.</p>
 <p>This talk covers a new way to build these systems using Deep Reinforcement Learning to improve the quality &amp; diversity of recommendations.</p>'
+        level: Intermediate
 
     - name: "Lunch"
       date: "31/10/2019"
@@ -262,8 +265,11 @@ I have also co-authored the recently-released 'Hands-on Deep Learning in Go', an
       presentation:
         title: "Sloc Cloc and Code - Can a crusty Go program outperform a well written Rust Project?"
         description: '<p>Sloc cloc and code. How a death march project lead to learning Go, the creation of a source lines of code counter which is faster and more accurate then the Rust/ATS/C equivalents, while learning about some really bizarre performance characteristics.</p>'
+        level: All levels
 
     - name: "Darrell Chua"
+      date: "31/10/2019"
+      time: "14:00"
       photo: "https://secure.gravatar.com/avatar/49e0e0dc2b4a1198f30f3de7ab63cb11?s=500"
       bio: "Darrell is a Senior Data Scientist with more than 10 years of experience. He has been programming in Go for a few years and has been working on Deep Learning models for longer. He has developed models of varying complexity; from building credit scorecards with logistic regression to building image classification models for trading cards."
       company: "Kablamo"
@@ -273,8 +279,7 @@ I have also co-authored the recently-released 'Hands-on Deep Learning in Go', an
       presentation:
         title: "Getting Started with Deep Learning in Go"
         description: '<p>Have you ever wanted to dabble in Deep Learning? Here&#39;s your chance to get started doing it in Go. We&#39;ll take you through a quick example of a new model - and then how to continue your learning process through more commonly found Tensorflow projects lying around the Internet.</p>'
-        date: "31/10/2019"
-        time: "14:00"
+        level: Beginners
 
     - name: "Coffee-break"
       date: "31/10/2019"
@@ -297,6 +302,7 @@ An active influencer in the technology community, He is a trustee of the Emergin
       presentation:
         title: "Go Gamble on Unicorn"
         description: '<p>We will be going through the journey of scaling a company to unicorn, I am going to talk about how GoLang helped us scale 6000x over 36 months and 18+ product lines,  where we failed and excelled with GoLang. Welcome to our journey and learnings of building software, teams and products</p>'
+        level: All levels
 
     - name: "Check-in / Breakfast"
       date: "1/11/2019"
@@ -315,6 +321,7 @@ An active influencer in the technology community, He is a trustee of the Emergin
       presentation:
         title: "Designing Go services for Continuous Deployment"
         description: '<p>Continuous Delivery can drive the design of your code for Great Good. I&#39;ll share some of the tricks and strategies I&#39;ve used to deploy Go services safely, smoothly, and without ceremony. I&#39;ll cover integration testing, db migrations, zero-downtime deploys, feature flags, and some useful go tooling.</p>'
+        level: All levels
 
     - name: "Alexander Else"
       date: "1/11/2019"
@@ -329,6 +336,7 @@ An active influencer in the technology community, He is a trustee of the Emergin
         title: "Eliminate the guess work: Profiling a go service in production"
         description: '<p>This talk is about how to start using go&#39;s profiling tools, instrument your code so that you can profile your services running in production and have less mystery in your life.</p>
 <p>Viewers will learn how to use trace and pprof tools, and guidance on doing it in production for their own services.</p>'
+        level: All levels
 
     - name: "Lunch"
       date: "1/11/2019"
@@ -346,6 +354,7 @@ An active influencer in the technology community, He is a trustee of the Emergin
       presentation:
         title: "Pragmatic Concurrency"
         description: '<p>Concurrency is one of Go&#39;s big selling points, but it&#39;s also something that trips up developers and  leads to projects stalling under the weight of complexity. I discuss my experience working on large concurrent systems, outline some common pitfalls, and share some opinions on best practices.</p>'
+        level: Intermediate
 
     - name: "Joshua Carpeggiani"
       date: "1/11/2019"
@@ -360,6 +369,7 @@ Outside of work, Josh likes to get lost by following the forgotten art of hitchh
       presentation:
         title: "Go for Decimals"
         description: '<p>Relying on binary floating point can kill; they are inherently imprecise and can lead to technical complications later down the road. A decimal system would solve many of these complications. Go has been lacking a fast and efficient decimal data type, until now...</p>'
+        level: All levels
 
     - name: "Coffee-break"
       date: "1/11/2019"
@@ -377,6 +387,7 @@ Outside of work, Josh likes to get lost by following the forgotten art of hitchh
       presentation:
         title: "Migrate to a New Platform by Creating a Pipeline in Go"
         description: '<p>This is the story of how Atlassian moved from a multi-million dollar contract with one vendor to another for their monitoring system. To help them migrate the thousands of engineers and microservices onto the new platform in just a few months, they built a new data pipeline using Go.</p>'
+        level: All levels
 
   # section2:
   #   title: You're here because you want the best

--- a/hugo/themes/hugo-fresh/layouts/partials/speakers.html
+++ b/hugo/themes/hugo-fresh/layouts/partials/speakers.html
@@ -26,6 +26,13 @@
           {{ end }} -->
         </h3>
         <h4 class="has-text-centered speakers-company">{{ .company }}</h4>
+        <h4 class="has-text-centered speakers-card-talk-title" >{{ .presentation.title }}</h4>
+        <h5 class="card-subtitle speakers-card-talk-subtitle has-text-centered">Talk</h5>
+        <h4 class="has-text-centered speakers-card-section-title">Description</h4>
+        <div class="speakers-bio has-text-justified">{{ .presentation.description | safeHTML }}</div>
+        <!-- <h4 class="has-text-centered speakers-card-section-title">Target Audience Level</h4>
+        <p class="has-text-centered">{{ .presentation.level }}</p> -->
+        <h4 class="has-text-centered speakers-card-section-title">About {{ .name }}</h4>
         <div class="speakers-bio has-text-justified">{{ .bio | safeHTML }}</div>
       </li>
       {{ end }}

--- a/hugo/themes/hugo-fresh/static/css/additional-styles.css
+++ b/hugo/themes/hugo-fresh/static/css/additional-styles.css
@@ -62,6 +62,27 @@
   list-style: inside;
 }
 
+.speakers-card-talk-title {
+  color: var(--dark-gray);
+  font-size: 1.5em;
+  margin-top: 0.5em;
+}
+
+.speakers-card-talk-subtitle {
+  font-weight: bold;
+  margin-top: 0.1em !important;
+  margin-bottom: 0.5em !important;
+  text-transform: uppercase;
+  color: var(--golden-yellow) !important;
+}
+
+.speakers-card-section-title {
+  color: var(--gopher-blue-dark);
+  margin-top: 1em;
+  margin-bottom: 0.1em;
+  font-weight: bold;
+}
+
 .divider.primary {
   background-color: var(--dark-gray);
 }


### PR DESCRIPTION
Changes:

* No changes to talk descriptions as it was already in the config file.
* Double-checked if it seems to match the proposed CFP abstracts.
* Added the descriptions to the speakers cards.
* Added audience levels to the talks, but has not made live yet - might be too restrictive?
* Styling.

![speakers-talk-desc](https://user-images.githubusercontent.com/48232387/65481657-7264f800-ded9-11e9-927e-adf38665e06e.png)
